### PR TITLE
Work in Progress

### DIFF
--- a/UNAPI/TELNET/src/UnapiHelper.c
+++ b/UNAPI/TELNET/src/UnapiHelper.c
@@ -39,6 +39,7 @@
 #include "../../fusion-c/header/msx_fusion.h"
 #include "../../fusion-c/header/asm.h"
 #include "UnapiHelper.h"
+#include "print.h"
 
 unapi_code_block helperCodeBlock;
 Z80_registers helperRegs; //auxiliary structure for asm function calling
@@ -170,11 +171,11 @@ unsigned char ResolveDNS(unsigned char * uchHostString, unsigned char * ucIP)
     {
 #ifdef UNAPIHELPER_VERBOSE
         if(helperRegs.Bytes.A == ERR_NO_NETWORK)
-            Print("No network connection available\n");
+            print("No network connection available\r\n");
         else if(helperRegs.Bytes.A == ERR_NO_DNS)
-            Print("There are no DNS servers configured\n");
+            print("There are no DNS servers configured\r\n");
         else if(helperRegs.Bytes.A == ERR_NOT_IMP)
-            Print("This TCP/IP UNAPI implementation does not support resolving host names.\nSpecify an IP address instead.\n");
+            print("This TCP/IP UNAPI implementation does not support resolving host names.\nSpecify an IP address instead.\r\n");
         else
             printf("Unknown error when resolving the host name (code %i)\r\n", helperRegs.Bytes.A);
 #endif
@@ -193,17 +194,17 @@ unsigned char ResolveDNS(unsigned char * uchHostString, unsigned char * ucIP)
     {
 #ifdef UNAPIHELPER_VERBOSE
         if(helperRegs.Bytes.B == 2)
-            Print("DNS server failure\n");
+            print("DNS server failure\r\n");
         else if(helperRegs.Bytes.B == 3)
-            Print("Unknown host name\n");
+            print("Unknown host name\r\n");
         else if(helperRegs.Bytes.B == 5)
-            Print("DNS server refused the query\n");
+            print("DNS server refused the query\r\n");
         else if(helperRegs.Bytes.B == 16 || helperRegs.Bytes.B == 17)
-            Print("DNS server did not reply\n");
+            print("DNS server did not reply\r\n");
         else if(helperRegs.Bytes.B == 19)
-            Print("No network connection available\n");
+            print("No network connection available\r\n");
         else if(helperRegs.Bytes.B == 0)
-            Print("DNS query failed\n");
+            print("DNS query failed\r\n");
         else
             printf("Unknown error returned by DNS server (code %i)\r\n", helperRegs.Bytes.B);
 #endif
@@ -257,9 +258,9 @@ unsigned char OpenSingleConnection (unsigned char * uchHost, unsigned char * uch
         {
 #ifdef UNAPIHELPER_VERBOSE
             if(uchRet == ERR_NO_FREE_CONN)
-                Print("No free TCP connections available\n");
+                print("No free TCP connections available\r\n");
             else if(uchRet == ERR_CONN_EXISTS)
-                Print("There is a resident TCP connection which uses the same IP/Port combination\n");
+                print("There is a resident TCP connection which uses the same IP/Port combination\r\n");
             else
                 printf("Unknown error when opening TCP connection (code %i)\r\n", helperRegs.Bytes.A);
 #endif

--- a/UNAPI/TELNET/src/XYMODEM.c
+++ b/UNAPI/TELNET/src/XYMODEM.c
@@ -41,6 +41,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "XYMODEM.h"
+#include "print.h"
 
 //X and YMODEM Vars
 __at 0xB000 unsigned char RcvPkt[]; //make sure it works in your map file, need to be in 0x8000 and beyond
@@ -521,9 +522,9 @@ void XYModemGet (unsigned char chConn, unsigned char chTelnetTransfer)
 	chTransferConn = chConn;
 	chDoubleFF = chTelnetTransfer;
 
-    Print("\r\nXMODEM Download type file Name\nYMODEM Download type Y\nYMODEM-G Download type G: ");
+    print("\r\n\r\nXMODEM Download type file Name\r\nYMODEM Download type Y\r\nYMODEM-G Download type G: ");
 	InputString(filename,sizeof(filename-1));
-	Print("\n");
+	print("\r\n");
 
 	if ( ((filename[0]=='g')||(filename[0]=='G')) && (filename[1]==0) )
         G=1;
@@ -553,7 +554,7 @@ void XYModemGet (unsigned char chConn, unsigned char chTelnetTransfer)
                 ret = XYModemPacketReceive (&iFile, 'C', PktNumber, 1);
 
             //Our nice animation to show we are not stuck
-            PrintChar('S');
+            putchar('S');
             if (ret == 255) //Created a file, cool, let's move on
             {
                 // A key has been hit?
@@ -595,8 +596,8 @@ void XYModemGet (unsigned char chConn, unsigned char chTelnetTransfer)
                         }
 
                         //Our nice animation to show we are not stuck
-                        PrintChar(8); //backspace
-                        PrintChar(advance[PktNumber%4]); // next char
+                        putchar(8); //backspace
+                        putchar(advance[PktNumber%4]); // next char
 
                         ++PktNumber; //next packet
                         if (G)
@@ -608,27 +609,27 @@ void XYModemGet (unsigned char chConn, unsigned char chTelnetTransfer)
 
                     if (ret == 0) //Time Out or other errors
                     {
-                        Print ("Error receiving file\n");
+                        print ("Error receiving file\r\n");
                         key = 0x1b; //force send of CAN CAN CAN CAN CAN
                     }
                     else if (ret == CAN) //Host canceled the transfer
                     {
                         //Ok, just ACK it
                         XYModemPacketReceive (&iNoFile, ACK, PktNumber, 1);
-                        Print ("Server canceled transfer\n");
+                        print ("Server canceled transfer\r\n");
                     }
                     else if ((ret == EOT)||(ret == ETB)) //End of Transmission
                     {
                         //Ok, just ACK it
                         XYModemPacketReceive (&iNoFile, ACK, PktNumber, 1);
-                        Print ("File Transfer Completed!\n");
+                        print ("File Transfer Completed!\r\n");
                     }
                     else if (key == 0x1b) //esc?
                         break;
                 }
                 else //error starting CRC section
                 {
-                    Print("Timeout waiting for file...\n");
+                    print("Timeout waiting for file...\r\n");
                     key = 0x1b; //force send of CAN CAN CAN CAN CAN
                 }
 
@@ -642,7 +643,7 @@ void XYModemGet (unsigned char chConn, unsigned char chTelnetTransfer)
             }
             else
             {
-                Print("Unknown error waiting for file...\n");
+                print("Unknown error waiting for file...\r\n");
                 key = 0x1b; //force send of CAN CAN CAN CAN CAN
                 break;
             }
@@ -658,7 +659,7 @@ void XYModemGet (unsigned char chConn, unsigned char chTelnetTransfer)
 		{
 			PktNumber = 1;
 			//Our nice animation to show we are not stuck
-			PrintChar('S');
+			putchar('S');
 			// Request start of XMODEM 1K
 			ret = XYModemPacketReceive (&iFile, 'C', PktNumber, 0);
 			if (ret)
@@ -674,8 +675,8 @@ void XYModemGet (unsigned char chConn, unsigned char chTelnetTransfer)
                             break;
                     }
 					//Our nice animation to show we are not stuck
-					PrintChar(8);
-					PrintChar(advance[PktNumber%4]);
+					putchar(8);
+					putchar(advance[PktNumber%4]);
 					++PktNumber;
 					ret = XYModemPacketReceive (&iFile, ACK, PktNumber, 0);
 				}
@@ -683,23 +684,23 @@ void XYModemGet (unsigned char chConn, unsigned char chTelnetTransfer)
 
 				if (ret == 0) //Time Out or other errors
                 {
-					Print ("Error receiving file\n");
+					print ("Error receiving file\r\n");
 					key = 0x1b; //force send of CAN CAN CAN CAN CAN
                 }
 				else if (ret == CAN) //Host canceled the transfer
 				{
 					XYModemPacketReceive (&iNoFile, ACK, PktNumber, 0);
-					Print ("Server canceled transfer\n");
+					print ("Server canceled transfer\r\n");
 				}
 				else if ((ret == EOT)||(ret == ETB)) //End of Transmission
 				{
 					XYModemPacketReceive (&iNoFile, ACK, PktNumber, 0);
-					Print ("File Transfer Completed!\n");
+					print ("File Transfer Completed!\r\n");
 				}
 			}
 			else //error starting CRC section
             {
-				Print("Timeout waiting for file...\n");
+				print("Timeout waiting for file...\r\n");
 				key = 0x1b; //force send of CAN CAN CAN CAN CAN
             }
 

--- a/UNAPI/TELNET/src/print.c
+++ b/UNAPI/TELNET/src/print.c
@@ -1,0 +1,42 @@
+// This print function has been copied from HGET / Konamiman
+// Using it as fusion-c Print uses bios calls, and do not work with PUT9000
+// That hooks the dos call.
+void print(char* s) __naked
+{
+    __asm
+    push    ix
+    ld     ix,#4
+    add ix,sp
+    ld  l,(ix)
+    ld  h,1(ix)
+loop:
+    ld  a,(hl)
+    or  a
+    jr  z,end
+    ld  e,a
+    ld  c,#2
+    push    hl
+    call    #5
+    pop hl
+    inc hl
+    jr  loop
+end:
+    pop ix
+    ret
+    __endasm;
+}
+
+void print_strout(char* s) __naked
+{
+    __asm
+    push    ix
+    ld     ix,#4
+    add ix,sp
+    ld  e,(ix)
+    ld  d,1(ix)
+    ld  c,#9
+    call    #5
+    pop ix
+    ret
+    __endasm;
+}

--- a/UNAPI/TELNET/src/print.h
+++ b/UNAPI/TELNET/src/print.h
@@ -1,0 +1,2 @@
+void print(char* s);
+void print_strout(char* s);


### PR DESCRIPTION
- Changed to print using ASM/DOS CALL only, fusion-c Print uses MSX-BIOS and PUT9000 do not work with it... :-P

- A big rework on the telnet Parse Data function, it is WAY, WAY BETTER... It has a bit better performance, now nearing the speed of JDUMP (that is the fastest you can go using jANSI) on adapters that do not use z80 too much (i.e.: GR8NET, MSX-SM, XSWiFi), of course that adapters that the driver executes z80 code with many tasks (OBSONET - really taxing on z80, DENYONET - faster than OBSONET and less z80 use but still more than the above mentioned adapters) . But the best part of it is that its code now is MUCH CLEANER to read and understand, using a switch/case state machine instead of many nested IFs (which on the other hand is friendlier to sdcc that do not like complex structures of nested IFs and can generated bugs.)

- Maybe some other minor changes that I do not remember...