### PR TITLE
Fixes #10

### DIFF
--- a/UNAPI/TELNET/src/Telnet.c
+++ b/UNAPI/TELNET/src/Telnet.c
@@ -2,10 +2,10 @@
 --
 -- telnet.c
 --   Simple TELNET client using UNAPI for MSX.
---   Revision 1.21
+--   Revision 1.23
 --
 -- Requires SDCC and Fusion-C library to compile
--- Copyright (c) 2019 Oduvaldo Pavan Junior ( ducasp@gmail.com )
+-- Copyright (c) 2019 - 2020 Oduvaldo Pavan Junior ( ducasp@gmail.com )
 -- All rights reserved.
 --
 -- Redistribution and use of this source code or any derivative works, are
@@ -330,6 +330,7 @@ int main(char** argv, int argc)
 	unsigned char ucPort[6]; //will hold the port that the server accepts connections
     unsigned char ucAliveConnCount = 0; //when this is 0, check if connection is alive
     char chTextLine[128];
+    unsigned char ucCursorSave;
 
     //we detect if enter was hit to avoid popping up protocol selection if transmit binary command is received in initial negotiations
     ucEnterHit = 0;
@@ -337,6 +338,8 @@ int main(char** argv, int argc)
     uiGetSize = 0;
     // For now, let's say we do not have ANSI
 	ucAnsi = 0;
+	//save cursor status
+	ucCursorSave = ucCursorDisplayed;
 
 	// Telnet Protocol Flags
     // Flag that indicates that a SUB OPTION reception is in progress
@@ -352,6 +355,8 @@ int main(char** argv, int argc)
 		// If invalid parameters, just show some instructions
 		print(ucSWInfo);
 		print(ucUsage);
+		//restore cursor status
+        ucCursorDisplayed = ucCursorSave;
 		return 0;
 	}
 
@@ -391,6 +396,8 @@ int main(char** argv, int argc)
     {
         if (ucAnsi) //loaded ansi-drv.bin?
             endAnsi();
+        //restore cursor status
+        ucCursorDisplayed = ucCursorSave;
         return 0;
     }
 
@@ -415,8 +422,9 @@ int main(char** argv, int argc)
             //UNAPI Breathing just in case adapter need it
             UnapiBreath();
 
+            ucTxData = Inkey ();
             // A key has been hit?
-            if (KeyboardHit())
+            if (ucTxData)
             {
                 // Get the key
                 ucTxData = InputChar ();
@@ -508,7 +516,8 @@ int main(char** argv, int argc)
         print (chTextLine);
     }
 
-    print(ucCursor_On);
+    //restore cursor status
+    ucCursorDisplayed = ucCursorSave;
 
 	return 0;
 }

--- a/UNAPI/TELNET/src/Telnet.h
+++ b/UNAPI/TELNET/src/Telnet.h
@@ -2,7 +2,7 @@
 --
 -- telnet.h
 --   Simple TELNET client using UNAPI for MSX.
---   Revision 1.22
+--   Revision 1.23
 --
 -- Requires SDCC and Fusion-C library to compile
 -- Copyright (c) 2019 Oduvaldo Pavan Junior ( ducasp@gmail.com )
@@ -108,9 +108,8 @@ const char ucUsage[] = "Usage: telnet <server:port> [a] [r]\r\n\r\n"
                        "r: if file transfer fails try using this, some BBSs misbehave on file transfers\r\n\r\n";
 
 //Versions
-const char ucSWInfo[] = "> MSX UNAPI TELNET Client v1.22 <\r\n (c) 2019 Oduvaldo Pavan Junior - ducasp@gmail.com\r\n\r\n";
-const char ucSWInfoANSI[] = "\x1b[31m> MSX UNAPI TELNET Client v1.22 <\r\n (c) 2019 Oduvaldo Pavan Junior - ducasp@gmail.com\x1b[0m\r\n";
-const char ucCursor_On[] = "\x1by5";
+const char ucSWInfo[] = "> MSX UNAPI TELNET Client v1.23 <\r\n (c) 2020 Oduvaldo Pavan Junior - ducasp@gmail.com\r\n\r\n";
+const char ucSWInfoANSI[] = "\x1b[31m> MSX UNAPI TELNET Client v1.23 <\r\n (c) 2020 Oduvaldo Pavan Junior - ducasp@gmail.com\x1b[0m\r\n";
 const char ucCursor_Up[] = "\x1b[A";
 const char ucCursor_Down[] = "\x1b[B";
 const char ucCursor_Forward[] = "\x1b[C";
@@ -137,6 +136,7 @@ unsigned char ucRcvData[128];
 __at 0xF3DC unsigned char ucCursorY;
 __at 0xF3DD unsigned char ucCursorX;
 __at 0xF3B0 unsigned char ucLinLen;
+__at 0xFCA9 unsigned char ucCursorDisplayed;
 
 //IMPORTANT: You need to check the map compiler generates to make sure this
 //address do not overlap functions, variables, etc


### PR DESCRIPTION
Fixes #10 

No longer send the escape code to turn on cursor on exit
Also copy CURSORSW value when entering the program and restore it before returning, just in case it get messed up in the future