### PR TITLE
Fix the Reset Attributes behavior.

### DIFF
--- a/SDCC/MSX2ANSI/SOURCECODE/msx2ansi.asm
+++ b/SDCC/MSX2ANSI/SOURCECODE/msx2ansi.asm
@@ -641,10 +641,10 @@ ANSI_DL:
 ANSI_SGR:						; ANSI Set Graphics Rendition
 	LD	A,B
 	OR	A
-	;JR	Z,ANSI_SGR.RET
-	; OPJ: Zero parameters -> Reset attributes
-	JR	Z,ANSI_SGR.RES			; RESET ATTRIBUTES
 	LD	DE,#Parameters.PRM
+	; OPJ: Zero parameters -> Reset attributes, 
+	JR	NZ,ANSI_SGR.RLP			
+	LD	(DE),A
 ANSI_SGR.RLP:	
 	PUSH	BC
 	LD	A,(DE)
@@ -667,12 +667,17 @@ ANSI_SGR.UNK:
 ANSI_SGR.RET:	
 	LD	HL,(#EndAddress)
 	JP	PrintText.RLP
-ANSI_SGR.RES:	
-	XOR	A						; RESET ATTRIBUTES
+ANSI_SGR.RES:
+	; PK: Reset text attributes, they are:
+	;	1 Bold
+	;	4 Underscore
+	;	5 Blink on
+	;	7 Reverse Video on
+	;	8 Concealed on
+	;     By now, the only one supported is BOLD
+	;
+	XOR	A				; RESET ATTRIBUTES
 	LD	(#HiLighted),A
-	LD	(#BackColor),A
-	LD	A,#0x07
-	LD	(#ForeColor),A
 	JR	ANSI_SGR.CLR
 ANSI_SGR.BLD:	
 	LD	A,#0x01
@@ -1782,7 +1787,6 @@ ForeColor:	.db	#0x07
 FontColor:	.db	#0x07
 
 HiLighted:	.db	#0x00
-
 
 ANSI_M:		.db	#0x00		; If ESC was the previous character will hold ESC, if processing ESC command, will hold [, otherwise 00
 ANSI_P:		.dw	#ANSI_S		; Point the next free position in buffer

--- a/SDCC/MSX2ANSI/SOURCECODE/msx2ansi.asm
+++ b/SDCC/MSX2ANSI/SOURCECODE/msx2ansi.asm
@@ -645,6 +645,7 @@ ANSI_SGR:						; ANSI Set Graphics Rendition
 	; OPJ: Zero parameters -> Reset attributes, 
 	JR	NZ,ANSI_SGR.RLP			
 	LD	(DE),A
+	LD	B,#0x01
 ANSI_SGR.RLP:	
 	PUSH	BC
 	LD	A,(DE)
@@ -667,17 +668,25 @@ ANSI_SGR.UNK:
 ANSI_SGR.RET:	
 	LD	HL,(#EndAddress)
 	JP	PrintText.RLP
-ANSI_SGR.RES:
-	; PK: Reset text attributes, they are:
-	;	1 Bold
-	;	4 Underscore
-	;	5 Blink on
-	;	7 Reverse Video on
-	;	8 Concealed on
-	;     By now, the only one supported is BOLD
-	;
-	XOR	A				; RESET ATTRIBUTES
+ANSI_SGR.RES:					; RESET ATTRIBUTES
+					; PK: Reset text attributes, they 
+					;     are:
+					;	1 Bold
+					;	4 Underscore
+					;	5 Blink on
+					;	7 Reverse Video on
+					;	8 Concealed on
+					;     By now, the only one supported
+					;     is BOLD
+	XOR	A				
 	LD	(#HiLighted),A
+					; PK: Some softwares expects that 
+					;     reset restore the text and
+					;     background colors to a sane 
+					;     default
+	LD	(#BackColor),A
+	LD	A,#0x07
+	LD	(#ForeColor),A
 	JR	ANSI_SGR.CLR
 ANSI_SGR.BLD:	
 	LD	A,#0x01


### PR DESCRIPTION
 Calling RST directly was hanging the terminal.

This fixes #19 

Now ESC[m; is "transformed" in ESC[0m; and goes through ANSI_SGR.RLP loop.

Also, reset attributes does not changes the terminal colors. It unsets the additional text attributes which are:

1 Bold
4 Underscore
5 Blink on
7 Reverse Video on
8 Concealed on

By now, only the BOLD is supported in MSX2ANSI. So I fixed this behavior, too.